### PR TITLE
Fix Night and Day Events by moving to Hall of Doors Lobby region

### DIFF
--- a/event_rules.py
+++ b/event_rules.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
-from .rule_builder_overrides import Has, HasAll, CanReachLocation
+from .rule_builder_overrides import Has, HasAll, CanReachLocation, CanReachRegion
 from .items import DeathsDoorItemName as I
 from .locations import DeathsDoorLocationName as L
+from .regions import DeathsDoorRegionName as R
 from .options import StartDayOrNight
 from .events import (
     DeathsDoorEventLocationName as EL,
@@ -41,9 +42,9 @@ deaths_door_event_rules: dict[EL, Rule["DeathsDoorWorld"] | None] = {
     EL.VICTORY: CanReachLocation(L.RUSTY_BELLTOWER_KEY),  # TODO: Goals
     EL.LOST_CEMETERY_OPENED_EXIT_TO_SAILOR: Has(I.FIRE),
     EL.ACCESS_TO_NIGHT: True_(options=[OptionFilter(StartDayOrNight, 1)])
-    | Has(I.RUSTY_BELLTOWER_KEY),
+    | (Has(I.RUSTY_BELLTOWER_KEY) & CanReachRegion(R.LOST_CEMETERY_BELLTOWER)),
     EL.ACCESS_TO_DAY: True_(options=[OptionFilter(StartDayOrNight, 0)])
-    | Has(I.RUSTY_BELLTOWER_KEY),
+    | (Has(I.RUSTY_BELLTOWER_KEY) & CanReachRegion(R.LOST_CEMETERY_BELLTOWER)),
     EL.GREY_CROW_BOSS: HasAll(
         I.GIANT_SOUL_OF_BETTY,
         I.GIANT_SOUL_OF_THE_FROG_KING,

--- a/events.py
+++ b/events.py
@@ -102,12 +102,12 @@ event_location_table: List[DeathsDoorEventLocationData] = [
     ),
     DeathsDoorEventLocationData(
         DeathsDoorEventLocationName.ACCESS_TO_NIGHT,
-        R.LOST_CEMETERY_BELLTOWER,
+        R.HALL_OF_DOORS_LOBBY,
         DeathsDoorEventName.ACCESS_TO_NIGHT,
     ),
     DeathsDoorEventLocationData(
         DeathsDoorEventLocationName.ACCESS_TO_DAY,
-        R.LOST_CEMETERY_BELLTOWER,
+        R.HALL_OF_DOORS_LOBBY,
         DeathsDoorEventName.ACCESS_TO_DAY,
     ),
     DeathsDoorEventLocationData(


### PR DESCRIPTION
Night and Day events need to not be in the Belltower region because of starting time yaml option. Changing however, does require that region access.