### PR TITLE
Change lighting Lord lamps to events (and clean up many event names)

### DIFF
--- a/entrances/lockstone_entrances.py
+++ b/entrances/lockstone_entrances.py
@@ -41,7 +41,7 @@ lockstone_entrances: list[DeathsDoorEntrance] = [
     ),
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_LORD_OPENGATE, R.CASTLE_LOCKSTONE_SOUTHWEST_CROW, None
-    ),  # TODO: See if this connection should require Fire (implicit with current connection)
+    ),
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_CENTRAL,
         R.CASTLE_LOCKSTONE_EAST,
@@ -70,7 +70,7 @@ lockstone_entrances: list[DeathsDoorEntrance] = [
         Has(I.LEVER_LOCKSTONE_EAST_START_SHORTCUT),
     ),
     DeathsDoorEntrance(
-        R.CASTLE_LOCKSTONE_LORD_DEADBOLT,  ## TODO: Check if this connection needs Fire, because Deadbolt region has it built in (might need to split lamp from region)
+        R.CASTLE_LOCKSTONE_LORD_DEADBOLT,
         R.CASTLE_LOCKSTONE_LIBRARY,
         None,
     ),
@@ -82,17 +82,18 @@ lockstone_entrances: list[DeathsDoorEntrance] = [
     ),  # Fall down the elevator
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_CENTRAL,
-        R.CASTLE_LOCKSTONE_ROOF,
-        CanReachRegion(R.CASTLE_LOCKSTONE_LORD_DEADBOLT)
-        & CanReachRegion(R.CASTLE_LOCKSTONE_LORD_LOCKSTONE)
-        & CanReachRegion(R.CASTLE_LOCKSTONE_LORD_THEODOOR)
-        & CanReachRegion(R.CASTLE_LOCKSTONE_LORD_OPENGATE),
-    ),  # Can summon elevator ##TODO: See if lord lamps can be turned into events instead!
+        HasAll(
+            E.CASTLE_LOCKSTONE_LORD_THEODOOR,
+            E.CASTLE_LOCKSTONE_LORD_DEADBOLT,
+            E.CASTLE_LOCKSTONE_LORD_LOCKSTONE,
+            E.CASTLE_LOCKSTONE_LORD_OPENGATE,
+        ),
+    ),  # Can summon elevator
     DeathsDoorEntrance(R.CASTLE_LOCKSTONE_EXIT_TO_CAMP, R.CASTLE_LOCKSTONE_ROOF, None),
     DeathsDoorEntrance(R.CASTLE_LOCKSTONE_ROOF, R.CASTLE_LOCKSTONE_EXIT_TO_CAMP, None),
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_EAST_UPPER_KEYED_DOOR,
-        R.CASTLE_LOCKSTONE_LORD_THEODOOR_ROOM,
+        R.CASTLE_LOCKSTONE_LORD_THEODOOR,
         Has(I.PINK_KEY, 5)
         & HasAll(I.HOOKSHOT, I.LEVER_LOCKSTONE_UPPER_DUAL_LASER_PUZZLE),
     ),
@@ -108,25 +109,20 @@ lockstone_entrances: list[DeathsDoorEntrance] = [
         ),
     ),
     DeathsDoorEntrance(
-        R.CASTLE_LOCKSTONE_CENTRAL, R.CASTLE_LOCKSTONE_LORD_LOCKSTONE, Has(I.FIRE)
+        R.CASTLE_LOCKSTONE_CENTRAL, R.CASTLE_LOCKSTONE_LORD_LOCKSTONE, None
     ),
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_CENTRAL,
         R.CASTLE_LOCKSTONE_LORD_OPENGATE,
-        HasAll(I.FIRE, I.HOOKSHOT, I.LEVER_LOCKSTONE_HOOKSHOT_PUZZLE),
+        HasAll(I.HOOKSHOT, I.LEVER_LOCKSTONE_HOOKSHOT_PUZZLE),
     ),
     DeathsDoorEntrance(
         R.CASTLE_LOCKSTONE_EAST_UPPER_KEYED_DOOR,
         R.CASTLE_LOCKSTONE_LORD_DEADBOLT,
-        HasAll(I.FIRE, I.HOOKSHOT),
+        Has(I.HOOKSHOT),
     ),
     DeathsDoorEntrance(
-        R.CASTLE_LOCKSTONE_LORD_THEODOOR_ROOM,
         R.CASTLE_LOCKSTONE_LORD_THEODOOR,
-        Has(I.FIRE),
-    ),
-    DeathsDoorEntrance(
-        R.CASTLE_LOCKSTONE_LORD_THEODOOR_ROOM,
         R.CASTLE_LOCKSTONE_EAST_CROW,
         None,
     ),

--- a/event_rules.py
+++ b/event_rules.py
@@ -39,7 +39,7 @@ pot_specific_rules: dict[EL, Rule["DeathsDoorWorld"]] = {
 
 
 deaths_door_event_rules: dict[EL, Rule["DeathsDoorWorld"] | None] = {
-    EL.VICTORY: CanReachLocation(L.RUSTY_BELLTOWER_KEY),  # TODO: Goals
+    EL.LORD_OF_DOORS: CanReachLocation(L.RUSTY_BELLTOWER_KEY),  # TODO: Goals
     EL.LOST_CEMETERY_OPENED_EXIT_TO_SAILOR: Has(I.FIRE),
     EL.ACCESS_TO_NIGHT: True_(options=[OptionFilter(StartDayOrNight, 1)])
     | (Has(I.RUSTY_BELLTOWER_KEY) & CanReachRegion(R.LOST_CEMETERY_BELLTOWER)),
@@ -73,6 +73,10 @@ deaths_door_event_rules: dict[EL, Rule["DeathsDoorWorld"] | None] = {
         I.MAGICAL_FOREST_HORN, E.ACCESS_TO_DAY
     ),
     EL.RESCUE_GRUNT: Has(I.BOMB),
+    EL.CASTLE_LOCKSTONE_LORD_LOCKSTONE: Has(I.FIRE),
+    EL.CASTLE_LOCKSTONE_LORD_OPENGATE: Has(I.FIRE),
+    EL.CASTLE_LOCKSTONE_LORD_DEADBOLT: Has(I.FIRE),
+    EL.CASTLE_LOCKSTONE_LORD_THEODOOR: Has(I.FIRE),
 }
 
 # Add in pots to existing tables to be able to use the same infrastructure

--- a/events.py
+++ b/events.py
@@ -5,34 +5,42 @@ from .regions import DeathsDoorRegionName as R
 
 
 class DeathsDoorEventName(str, Enum):
-    VICTORY = "Goal Complete"
-    LOST_CEMETERY_OPENED_EXIT_TO_SAILOR = "Lost Cemetery Opened Exit to Sailor"
+    LORD_OF_DOORS = "Defeat the Lord of Doors"
+    LOST_CEMETERY_OPENED_EXIT_TO_SAILOR = "Lost Cemetery - Light Lamp to Open Exit to Stranded Sailor Caves"
     ACCESS_TO_NIGHT = "Access to Night"
     ACCESS_TO_DAY = "Access to Day"
-    GREY_CROW_BOSS = "Can Defeat Grey Crow Boss"
-    ACTIVATED_FURNACE_BURNERS = "Can Activate First Furnace Burner"
-    LIT_WATCHTOWER_TORCH = "Can Light a Watchtower Burner"
+    GREY_CROW_BOSS = "Lost Cemetery - Defeat Grey Crow Boss"
+    ACTIVATED_FURNACE_BURNERS = "Inner Furnace - Light First Furnace Burner"
+    LIT_WATCHTOWER_TORCH = "Old Watchtowers - Light a Torch"
     MUSHROOM_DUNGEON_MAIN_GATE = "Can Open the Mushroom Dungeon Main Gate"
-    RESCUE_GRUNT = "Can Rescue Grunt"
-    PLANTED_SEED = "Can Plant a Seed"
+    RESCUE_GRUNT = "Mushroom Dungeon - Rescue Grunt"
+    CASTLE_LOCKSTONE_LORD_LOCKSTONE = "Castle Lockstone - Light Lord Lockstone Lamp"
+    CASTLE_LOCKSTONE_LORD_OPENGATE = "Castle Lockstone - Light Lord Opengate Lamp"
+    CASTLE_LOCKSTONE_LORD_DEADBOLT = "Castle Lockstone - Light Lord Deadbolt Lamp"
+    CASTLE_LOCKSTONE_LORD_THEODOOR = "Castle Lockstone - Light Lord Theodoor Lamp"
+    PLANTED_SEED = "Plant a Seed"
     OOL = "Out of Logic Item"  # For Universal Tracker
 
 
 class DeathsDoorEventLocationName(str, Enum):
-    VICTORY = "Defeat the Lord of Doors"
-    LOST_CEMETERY_OPENED_EXIT_TO_SAILOR = "Lost Cemetery Lamp Switch Exit to Sailor"
+    LORD_OF_DOORS = "Lord of Doors"
+    LOST_CEMETERY_OPENED_EXIT_TO_SAILOR = "Lost Cemetery - Lamp for Exit to Stranded Sailor"
     ACCESS_TO_NIGHT = "Access to Night"
     ACCESS_TO_DAY = "Access to Day"
-    GREY_CROW_BOSS = "Grey Crow Boss"
-    ACTIVATED_FURNACE_BURNERS = "First Furnace Burner"
-    WATCHTOWER_ENTRANCE_TORCH = "Watchtower Entrance Torch"
-    WATCHTOWER_JAMMING_START_TORCH = "Watchtower Jamming Start Torch"
-    WATCHTOWER_BOXES_TORCH = "Watchtower Boxes Torch"
-    WATCHTOWER_FIRST_POT_TORCH = "Watchtower First Pot Area Torch"
-    WATCHTOWER_BOOMERS_TORCH_1 = "Watchtower Boomers Torch 1"
-    WATCHTOWER_BOOMERS_TORCH_2 = "Watchtower Boomers Torch 2"
-    MUSHROOM_DUNGEON_MAIN_GATE = "Mushroom Dungeon Main Gate"
-    RESCUE_GRUNT = "Mushroom Dungeon Grunt Rescue"
+    GREY_CROW_BOSS = "Lost Cemetery - Grey Crow Boss"
+    ACTIVATED_FURNACE_BURNERS = "Inner Furnace - First Furnace Burner"
+    WATCHTOWER_ENTRANCE_TORCH = "Old Watchtowers - Entrance Torch"
+    WATCHTOWER_JAMMING_START_TORCH = "Old Watchtowers - Jamming Start Torch"
+    WATCHTOWER_BOXES_TORCH = "Old Watchtowers - Boxes Torch"
+    WATCHTOWER_FIRST_POT_TORCH = "Old Watchtowers - First Pot Area Torch"
+    WATCHTOWER_BOOMERS_TORCH_1 = "Old Watchtowers - Boomers Torch 1"
+    WATCHTOWER_BOOMERS_TORCH_2 = "Old Watchtowers - Boomers Torch 2"
+    MUSHROOM_DUNGEON_MAIN_GATE = "Mushroom Dungeon - Main Gate"
+    RESCUE_GRUNT = "Mushroom Dungeon - Grunt"
+    CASTLE_LOCKSTONE_LORD_LOCKSTONE = "Castle Lockstone - Lord Lockstone Lamp"
+    CASTLE_LOCKSTONE_LORD_OPENGATE = "Castle Lockstone - Lord Opengate Lamp"
+    CASTLE_LOCKSTONE_LORD_DEADBOLT = "Castle Lockstone - Lord Deadbolt Lamp"
+    CASTLE_LOCKSTONE_LORD_THEODOOR = "Castle Lockstone - Lord Theodoor Lamp"
     POT_OUTSIDE_CATACOMBS_EXIT = "Pot-Outside_Catacombs_Exit"
     POT_CATACOMBS_ROOM_2 = "Pot-Catacombs_Room_2"
     POT_CEMETERY_RIGHT_ARENA = "Pot-Cemetery_Right_Arena"
@@ -93,7 +101,7 @@ class DeathsDoorEventLocationData(NamedTuple):
 
 event_location_table: List[DeathsDoorEventLocationData] = [
     DeathsDoorEventLocationData(
-        DeathsDoorEventLocationName.VICTORY, R.HALL_OF_DOORS_LOBBY, DeathsDoorEventName.VICTORY
+        DeathsDoorEventLocationName.LORD_OF_DOORS, R.HALL_OF_DOORS_LOBBY, DeathsDoorEventName.LORD_OF_DOORS
     ),
     DeathsDoorEventLocationData(
         DeathsDoorEventLocationName.LOST_CEMETERY_OPENED_EXIT_TO_SAILOR,
@@ -160,6 +168,10 @@ event_location_table: List[DeathsDoorEventLocationData] = [
         R.MUSHROOM_DUNGEON_LOBBY,
         DeathsDoorEventName.RESCUE_GRUNT,
     ),
+    DeathsDoorEventLocationData(DeathsDoorEventLocationName.CASTLE_LOCKSTONE_LORD_LOCKSTONE, R.CASTLE_LOCKSTONE_LORD_LOCKSTONE, DeathsDoorEventName.CASTLE_LOCKSTONE_LORD_LOCKSTONE),
+    DeathsDoorEventLocationData(DeathsDoorEventLocationName.CASTLE_LOCKSTONE_LORD_OPENGATE, R.CASTLE_LOCKSTONE_LORD_OPENGATE, DeathsDoorEventName.CASTLE_LOCKSTONE_LORD_OPENGATE),
+    DeathsDoorEventLocationData(DeathsDoorEventLocationName.CASTLE_LOCKSTONE_LORD_DEADBOLT, R.CASTLE_LOCKSTONE_LORD_DEADBOLT, DeathsDoorEventName.CASTLE_LOCKSTONE_LORD_DEADBOLT),
+    DeathsDoorEventLocationData(DeathsDoorEventLocationName.CASTLE_LOCKSTONE_LORD_THEODOOR, R.CASTLE_LOCKSTONE_LORD_THEODOOR, DeathsDoorEventName.CASTLE_LOCKSTONE_LORD_THEODOOR),
 ]
 
 pot_table: List[DeathsDoorEventLocationData] = [

--- a/regions.py
+++ b/regions.py
@@ -223,18 +223,15 @@ class DeathsDoorRegionName(str, Enum):
     CASTLE_LOCKSTONE_EAST_UPPER = "Castle Lockstone East Upper"
     CASTLE_LOCKSTONE_EAST_UPPER_KEYED_DOOR = "Castle Lockstone East Upper Keyed Door"
     CASTLE_LOCKSTONE_JAILED_SEED = "Castle Lockstone Jailed Seed"
-    CASTLE_LOCKSTONE_LORD_THEODOOR_ROOM = (
-        "Castle Lockstone Lord Theodoor Room"  # Called Lamp in base rando
-    )
     CASTLE_LOCKSTONE_LIBRARY = "Castle Lockstone Library"
     CASTLE_LOCKSTONE_ROOF = "Castle Lockstone Roof"
     CASTLE_LOCKSTONE_EXIT_TO_CAMP = (
         "Castle Lockstone Exit to Camp of the Free Crows (via Roof)"
     )
-    CASTLE_LOCKSTONE_LORD_LOCKSTONE = "Castle Lockstone Lord Lockstone Light Lamp"
-    CASTLE_LOCKSTONE_LORD_OPENGATE = "Castle Lockstone Lord Opengate Light Lamp"
-    CASTLE_LOCKSTONE_LORD_DEADBOLT = "Castle Lockstone Lord Deadbolt Light Lamp"
-    CASTLE_LOCKSTONE_LORD_THEODOOR = "Castle Lockstone Lord Theodoor Light Lamp"
+    CASTLE_LOCKSTONE_LORD_LOCKSTONE = "Castle Lockstone Lord Lockstone's Grave"
+    CASTLE_LOCKSTONE_LORD_OPENGATE = "Castle Lockstone Lord Opengate's Grave"
+    CASTLE_LOCKSTONE_LORD_DEADBOLT = "Castle Lockstone Lord Deadbolt's Grave"
+    CASTLE_LOCKSTONE_LORD_THEODOOR = "Castle Lockstone Lord Theodoor's Grave"
     CASTLE_LOCKSTONE_EAST_CROW = "Castle Lockstone East Crow"
 
     # Camp of the Free Crows Regions

--- a/world.py
+++ b/world.py
@@ -216,7 +216,7 @@ class DeathsDoorWorld(RuleWorldMixin, World):
         set_location_rules(self)
         set_event_rules(self)
 
-        self.set_completion_rule(Has(E.VICTORY))
+        self.set_completion_rule(Has(E.LORD_OF_DOORS))
         self.register_dependencies()
 
         # generate_rule_json()


### PR DESCRIPTION
This change should reduce confusion between the lords' rooms as connections to other regions versus the role they serve as elevator switch lamps.