### PR TITLE
Fix Region on Old Watchtower torch

### DIFF
--- a/event_rules.py
+++ b/event_rules.py
@@ -63,10 +63,10 @@ deaths_door_event_rules: dict[EL, Rule["DeathsDoorWorld"] | None] = {
     EL.WATCHTOWER_FIRST_POT_TORCH: HasAll(
         I.FIRE, E.ACCESS_TO_NIGHT
     ),
-    EL.WATCHTOWER_BOOMERS_TORCH_1: HasAll(
+    EL.WATCHTOWER_BOOMERS_TORCH: HasAll(
         I.FIRE, E.ACCESS_TO_NIGHT
     ),
-    EL.WATCHTOWER_BOOMERS_TORCH_2: HasAll(
+    EL.WATCHTOWER_BEFORE_ICE_SKATING_TORCH: HasAll(
         I.FIRE, E.ACCESS_TO_NIGHT
     ),
     EL.MUSHROOM_DUNGEON_MAIN_GATE: HasAll(

--- a/events.py
+++ b/events.py
@@ -33,8 +33,8 @@ class DeathsDoorEventLocationName(str, Enum):
     WATCHTOWER_JAMMING_START_TORCH = "Old Watchtowers - Jamming Start Torch"
     WATCHTOWER_BOXES_TORCH = "Old Watchtowers - Boxes Torch"
     WATCHTOWER_FIRST_POT_TORCH = "Old Watchtowers - First Pot Area Torch"
-    WATCHTOWER_BOOMERS_TORCH_1 = "Old Watchtowers - Boomers Torch 1"
-    WATCHTOWER_BOOMERS_TORCH_2 = "Old Watchtowers - Boomers Torch 2"
+    WATCHTOWER_BOOMERS_TORCH = "Old Watchtowers - Boomers Torch"
+    WATCHTOWER_BEFORE_ICE_SKATING_TORCH = "Old Watchtowers - Before Ice Skating Torch"
     MUSHROOM_DUNGEON_MAIN_GATE = "Mushroom Dungeon - Main Gate"
     RESCUE_GRUNT = "Mushroom Dungeon - Grunt"
     CASTLE_LOCKSTONE_LORD_LOCKSTONE = "Castle Lockstone - Lord Lockstone Lamp"
@@ -149,13 +149,13 @@ event_location_table: List[DeathsDoorEventLocationData] = [
         DeathsDoorEventName.LIT_WATCHTOWER_TORCH,
     ),
     DeathsDoorEventLocationData(
-        DeathsDoorEventLocationName.WATCHTOWER_BOOMERS_TORCH_1,
+        DeathsDoorEventLocationName.WATCHTOWER_BOOMERS_TORCH,
         R.OLD_WATCHTOWERS_BOOMERS,
         DeathsDoorEventName.LIT_WATCHTOWER_TORCH,
     ),
     DeathsDoorEventLocationData(
-        DeathsDoorEventLocationName.WATCHTOWER_BOOMERS_TORCH_2,
-        R.OLD_WATCHTOWERS_BOOMERS,
+        DeathsDoorEventLocationName.WATCHTOWER_BEFORE_ICE_SKATING_TORCH,
+        R.OLD_WATCHTOWERS_ICE_SKATING_START,
         DeathsDoorEventName.LIT_WATCHTOWER_TORCH,
     ),
     DeathsDoorEventLocationData(


### PR DESCRIPTION
Difference from base rando. One Old Watchtower torch that was marked in base rando as being accessible from "Boomers" must be accessed from "Before Ice Skating" instead

Closes #19 