### PR TITLE
Remove bomb requirement from Estate South to North traversal

### DIFF
--- a/entrances/estate_entrances.py
+++ b/entrances/estate_entrances.py
@@ -38,7 +38,7 @@ estate_entrances: list[DeathsDoorEntrance] = [
     DeathsDoorEntrance(
         R.ESTATE_OF_THE_URN_WITCH_SOUTH,
         R.ESTATE_OF_THE_URN_WITCH_NORTH,
-        HasAll(I.LEVER_GARDEN_OF_JOY, I.LEVER_GARDEN_OF_PEACE, I.BOMB),
+        HasAll(I.LEVER_GARDEN_OF_JOY, I.LEVER_GARDEN_OF_PEACE),
     ),
     DeathsDoorEntrance(
         R.ESTATE_OF_THE_URN_WITCH_EXIT_TO_CERAMIC_MANOR,


### PR DESCRIPTION
Bomb is only needed on the way back.